### PR TITLE
Fix misleading "JSON to TOML" title

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
-  <title>Online JSON to TOML converter</title>
+  <title>Online TOML to JSON converter</title>
 
   <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,700|Inconsolata:400,700">
   <link rel="stylesheet" href="stylesheets/vendor/normalize.css">


### PR DESCRIPTION
Just found this site when looking for a _JSON to TOML_ converter, but was disappointed when I found out that it didn't actually convert JSON to TOML, as the title of the page says.
